### PR TITLE
Add configuration capabilities to FerrumPdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ Run the following or add the gem to your Gemfile:
 bundle add "ferrum_pdf"
 ```
 
+## Configuration
+
+You can configure FerrumPdf globally using an initializer. Create a file `config/initializers/ferrum_pdf.rb` in your Rails application:
+
+```ruby
+FerrumPdf.configure do |config|
+  config[:headless] = true
+  config[:timeout] = 20
+  config[:window_size] = [1280, 800]
+  # Add any other Ferrum options you want to set globally
+end
+```
+
+These options will be used as default settings for all FerrumPdf operations. You can still override these settings on a per-use basis when calling `render_pdf` or `render_screenshot`.
+
 ## Usage
 
 You can use FerrumPdf to render [PDFs](#pdfs) and [Screenshots](#screenshots)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ You can configure FerrumPdf globally using an initializer. Create a file `config
 
 ```ruby
 FerrumPdf.configure do |config|
-  config[:headless] = true
-  config[:process_timeout] = 30  # Time to wait for browser to start (in seconds)
-  config[:timeout] = 10          # Default timeout for operations (in seconds)
-  config[:window_size] = [1280, 800]
+  config.headless = true
+  config.process_timeout = 30  # Time to wait for browser to start (in seconds)
+  config.timeout = 10          # Default timeout for operations (in seconds)
+  config.window_size = [1280, 800]
   # Add any other Ferrum options you want to set globally
 end
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You can configure FerrumPdf globally using an initializer. Create a file `config
 ```ruby
 FerrumPdf.configure do |config|
   config[:headless] = true
-  config[:timeout] = 20
+  config[:process_timeout] = 30  # Time to wait for browser to start (in seconds)
+  config[:timeout] = 10          # Default timeout for operations (in seconds)
   config[:window_size] = [1280, 800]
   # Add any other Ferrum options you want to set globally
 end

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -25,7 +25,7 @@ module FerrumPdf
     end
 
     def reset_configuration!
-      @@configuration = {}
+      @@configuration = ActiveSupport::OrderedOptions.new
       @browser = nil  # Reset the browser instance when configuration is reset
     end
 

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -23,6 +23,10 @@ module FerrumPdf
       yield(configuration)
     end
 
+    def reset_configuration!
+      @@configuration = {}
+    end
+
     def browser
       @browser ||= Ferrum::Browser.new(configuration)
     end

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -15,9 +15,16 @@ module FerrumPdf
   mattr_accessor :include_controller_module
   @@include_controller_module = true
 
+  mattr_accessor :configuration
+  @@configuration = {}
+
   class << self
-    def browser(**options)
-      @browser ||= Ferrum::Browser.new(options)
+    def configure
+      yield(configuration)
+    end
+
+    def browser
+      @browser ||= Ferrum::Browser.new(configuration)
     end
 
     def render_pdf(html: nil, url: nil, host: nil, protocol: nil, pdf_options: {})

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -16,7 +16,7 @@ module FerrumPdf
   @@include_controller_module = true
 
   mattr_accessor :configuration
-  @@configuration = {}
+  @@configuration = ActiveSupport::OrderedOptions.new
 
   class << self
     def configure

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -21,10 +21,12 @@ module FerrumPdf
   class << self
     def configure
       yield(configuration)
+      @browser = nil  # Reset the browser instance when configuration changes
     end
 
     def reset_configuration!
       @@configuration = {}
+      @browser = nil  # Reset the browser instance when configuration is reset
     end
 
     def browser

--- a/lib/ferrum_pdf/railtie.rb
+++ b/lib/ferrum_pdf/railtie.rb
@@ -5,13 +5,5 @@ module FerrumPdf
         include FerrumPdf::Controller if FerrumPdf.include_controller_module
       end
     end
-
-    initializer "ferrum_pdf.load_configuration" do
-      config.after_initialize do
-        FerrumPdf.configure do |config|
-          # Load default configuration here if needed
-        end
-      end
-    end
   end
 end

--- a/lib/ferrum_pdf/railtie.rb
+++ b/lib/ferrum_pdf/railtie.rb
@@ -5,5 +5,13 @@ module FerrumPdf
         include FerrumPdf::Controller if FerrumPdf.include_controller_module
       end
     end
+
+    initializer "ferrum_pdf.load_configuration" do
+      config.after_initialize do
+        FerrumPdf.configure do |config|
+          # Load default configuration here if needed
+        end
+      end
+    end
   end
 end

--- a/test/dummy/config/initializers/ferrum_pdf.rb
+++ b/test/dummy/config/initializers/ferrum_pdf.rb
@@ -1,5 +1,5 @@
 FerrumPdf.configure do |config|
-  config[:headless] = true
-  config[:timeout] = 20
-  config[:window_size] = [ 1280, 800 ]
+  config.headless = true
+  config.timeout = 20
+  config.window_size = [ 1280, 800 ]
 end

--- a/test/dummy/config/initializers/ferrum_pdf.rb
+++ b/test/dummy/config/initializers/ferrum_pdf.rb
@@ -1,0 +1,5 @@
+FerrumPdf.configure do |config|
+  config[:headless] = true
+  config[:timeout] = 20
+  config[:window_size] = [ 1280, 800 ]
+end

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -7,45 +7,37 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
 
   test "configuration can be set through configure method" do
     FerrumPdf.configure do |config|
-      config[:headless] = true
-      config[:window_size] = [ 1024, 768 ]
-      config[:timeout] = 30
+      config.timeout = 30
+      config.window_size = [ 1024, 768 ]
     end
 
-    assert_equal true, FerrumPdf.configuration[:headless]
-    assert_equal 30, FerrumPdf.configuration[:timeout]
-    assert_equal [ 1024, 768 ], FerrumPdf.configuration[:window_size]
+    assert_equal 30, FerrumPdf.configuration.timeout
+    assert_equal [ 1024, 768 ], FerrumPdf.configuration.window_size
   end
 
   test "configuration is used when creating browser" do
     FerrumPdf.configure do |config|
-      config[:headless] = true
-      config[:timeout] = 45
+      config.timeout = 45
     end
 
     browser = FerrumPdf.browser
     assert_instance_of Ferrum::Browser, browser
-    assert_equal true, browser.instance_variable_get(:@options).headless
     assert_equal 45, browser.instance_variable_get(:@options).timeout
   end
 
   test "changing configuration creates new browser instance" do
     FerrumPdf.configure do |config|
-      config[:headless] = true
-      config[:timeout] = 30
+      config.timeout = 20
     end
     first_browser = FerrumPdf.browser
 
     FerrumPdf.configure do |config|
-      config[:headless] = true
-      config[:timeout] = 60
+      config.timeout = 30
     end
     second_browser = FerrumPdf.browser
 
     assert_not_equal first_browser.object_id, second_browser.object_id
-    assert_equal true, first_browser.instance_variable_get(:@options).headless
-    assert_equal true, second_browser.instance_variable_get(:@options).headless
-    assert_equal 30, first_browser.instance_variable_get(:@options).timeout
-    assert_equal 60, second_browser.instance_variable_get(:@options).timeout
+    assert_equal 20, first_browser.instance_variable_get(:@options).timeout
+    assert_equal 30, second_browser.instance_variable_get(:@options).timeout
   end
 end

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
+  setup do
+    FerrumPdf.reset_configuration!
+  end
+
   test "configuration can be set through configure method" do
     FerrumPdf.configure do |config|
       config[:headless] = true
@@ -21,13 +25,23 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
 
     browser = FerrumPdf.browser
     assert_instance_of Ferrum::Browser, browser
-    browser_options = browser.instance_variable_get(:@options)
-    assert_equal false, browser_options.headless
-    assert_equal 45, browser_options.timeout
+    assert_equal false, browser.instance_variable_get(:@options).headless
+    assert_equal 45, browser.instance_variable_get(:@options).timeout
   end
 
-  test "initializer sets default configuration" do
-    # This test assumes that the initializer in the dummy app sets some default values
-    assert_not_empty FerrumPdf.configuration
+  test "changing configuration creates new browser instance" do
+    FerrumPdf.configure do |config|
+      config[:headless] = true
+    end
+    first_browser = FerrumPdf.browser
+
+    FerrumPdf.configure do |config|
+      config[:headless] = false
+    end
+    second_browser = FerrumPdf.browser
+
+    assert_not_equal first_browser.object_id, second_browser.object_id
+    assert_equal true, first_browser.instance_variable_get(:@options).headless
+    assert_equal false, second_browser.instance_variable_get(:@options).headless
   end
 end

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
+  def setup
+    FerrumPdf.reset_configuration!
+  end
+
+  test "configuration can be set through initializer" do
+    FerrumPdf.configure do |config|
+      config[:headless] = true
+      config[:timeout] = 30
+      config[:window_size] = [ 1024, 768 ]
+    end
+
+    assert_equal true, FerrumPdf.configuration[:headless]
+    assert_equal 30, FerrumPdf.configuration[:timeout]
+    assert_equal [ 1024, 768 ], FerrumPdf.configuration[:window_size]
+  end
+
+  test "configuration is used when creating browser" do
+    FerrumPdf.configure do |config|
+      config[:headless] = false
+      config[:timeout] = 45
+    end
+
+    browser = FerrumPdf.browser
+    assert_instance_of Ferrum::Browser, browser
+    browser_options = browser.instance_variable_get(:@options)
+    assert_equal false, browser_options.headless
+    assert_equal 45, browser_options.timeout
+  end
+
+  test "default configuration is empty" do
+    assert_empty FerrumPdf.configuration
+  end
+end

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -1,11 +1,7 @@
 require "test_helper"
 
 class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
-  def setup
-    FerrumPdf.reset_configuration!
-  end
-
-  test "configuration can be set through initializer" do
+  test "configuration can be set through configure method" do
     FerrumPdf.configure do |config|
       config[:headless] = true
       config[:timeout] = 30
@@ -30,7 +26,8 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
     assert_equal 45, browser_options.timeout
   end
 
-  test "default configuration is empty" do
-    assert_empty FerrumPdf.configuration
+  test "initializer sets default configuration" do
+    # This test assumes that the initializer in the dummy app sets some default values
+    assert_not_empty FerrumPdf.configuration
   end
 end

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -8,12 +8,14 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
   test "configuration can be set through configure method" do
     FerrumPdf.configure do |config|
       config[:headless] = true
-      config[:timeout] = 30
       config[:window_size] = [ 1024, 768 ]
+      config[:timeout] = 30 # Default timeout for operations
+      config[:process_timeout] = 30 # Time to wait for browser to start
     end
 
     assert_equal true, FerrumPdf.configuration[:headless]
     assert_equal 30, FerrumPdf.configuration[:timeout]
+    assert_equal 30, FerrumPdf.configuration[:process_timeout]
     assert_equal [ 1024, 768 ], FerrumPdf.configuration[:window_size]
   end
 
@@ -21,22 +23,26 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
     FerrumPdf.configure do |config|
       config[:headless] = false
       config[:timeout] = 45
+      config[:process_timeout] = 30
     end
 
     browser = FerrumPdf.browser
     assert_instance_of Ferrum::Browser, browser
     assert_equal false, browser.instance_variable_get(:@options).headless
     assert_equal 45, browser.instance_variable_get(:@options).timeout
+    assert_equal 30, browser.instance_variable_get(:@options).process_timeout
   end
 
   test "changing configuration creates new browser instance" do
     FerrumPdf.configure do |config|
       config[:headless] = true
+      config[:process_timeout] = 30
     end
     first_browser = FerrumPdf.browser
 
     FerrumPdf.configure do |config|
       config[:headless] = false
+      config[:process_timeout] = 30
     end
     second_browser = FerrumPdf.browser
 

--- a/test/ferrum_pdf_configuration_test.rb
+++ b/test/ferrum_pdf_configuration_test.rb
@@ -9,45 +9,43 @@ class FerrumPdf::ConfigurationTest < ActiveSupport::TestCase
     FerrumPdf.configure do |config|
       config[:headless] = true
       config[:window_size] = [ 1024, 768 ]
-      config[:timeout] = 30 # Default timeout for operations
-      config[:process_timeout] = 30 # Time to wait for browser to start
+      config[:timeout] = 30
     end
 
     assert_equal true, FerrumPdf.configuration[:headless]
     assert_equal 30, FerrumPdf.configuration[:timeout]
-    assert_equal 30, FerrumPdf.configuration[:process_timeout]
     assert_equal [ 1024, 768 ], FerrumPdf.configuration[:window_size]
   end
 
   test "configuration is used when creating browser" do
     FerrumPdf.configure do |config|
-      config[:headless] = false
+      config[:headless] = true
       config[:timeout] = 45
-      config[:process_timeout] = 30
     end
 
     browser = FerrumPdf.browser
     assert_instance_of Ferrum::Browser, browser
-    assert_equal false, browser.instance_variable_get(:@options).headless
+    assert_equal true, browser.instance_variable_get(:@options).headless
     assert_equal 45, browser.instance_variable_get(:@options).timeout
-    assert_equal 30, browser.instance_variable_get(:@options).process_timeout
   end
 
   test "changing configuration creates new browser instance" do
     FerrumPdf.configure do |config|
       config[:headless] = true
-      config[:process_timeout] = 30
+      config[:timeout] = 30
     end
     first_browser = FerrumPdf.browser
 
     FerrumPdf.configure do |config|
-      config[:headless] = false
-      config[:process_timeout] = 30
+      config[:headless] = true
+      config[:timeout] = 60
     end
     second_browser = FerrumPdf.browser
 
     assert_not_equal first_browser.object_id, second_browser.object_id
     assert_equal true, first_browser.instance_variable_get(:@options).headless
-    assert_equal false, second_browser.instance_variable_get(:@options).headless
+    assert_equal true, second_browser.instance_variable_get(:@options).headless
+    assert_equal 30, first_browser.instance_variable_get(:@options).timeout
+    assert_equal 60, second_browser.instance_variable_get(:@options).timeout
   end
 end

--- a/test/ferrum_pdf_initializer_test.rb
+++ b/test/ferrum_pdf_initializer_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class FerrumPdfInitializerTest < ActiveSupport::TestCase
   test "initializer sets configuration" do
     # This test checks the configuration set by the initializer in the dummy app
-    assert_equal true, FerrumPdf.configuration[:headless]
-    assert_equal 20, FerrumPdf.configuration[:timeout]
-    assert_equal [ 1280, 800 ], FerrumPdf.configuration[:window_size]
+    assert_equal true, FerrumPdf.configuration.headless
+    assert_equal 20, FerrumPdf.configuration.timeout
+    assert_equal [ 1280, 800 ], FerrumPdf.configuration.window_size
   end
 end

--- a/test/ferrum_pdf_initializer_test.rb
+++ b/test/ferrum_pdf_initializer_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class FerrumPdfInitializerTest < ActiveSupport::TestCase
+  test "initializer sets configuration" do
+    # This assumes you have an initializer in your dummy app
+    # If not, you'll need to add one (see step 4)
+    assert_equal true, FerrumPdf.configuration[:headless]
+    assert_equal 20, FerrumPdf.configuration[:timeout]
+    assert_equal [ 1280, 800 ], FerrumPdf.configuration[:window_size]
+  end
+end

--- a/test/ferrum_pdf_initializer_test.rb
+++ b/test/ferrum_pdf_initializer_test.rb
@@ -2,8 +2,7 @@ require "test_helper"
 
 class FerrumPdfInitializerTest < ActiveSupport::TestCase
   test "initializer sets configuration" do
-    # This assumes you have an initializer in your dummy app
-    # If not, you'll need to add one (see step 4)
+    # This test checks the configuration set by the initializer in the dummy app
     assert_equal true, FerrumPdf.configuration[:headless]
     assert_equal 20, FerrumPdf.configuration[:timeout]
     assert_equal [ 1280, 800 ], FerrumPdf.configuration[:window_size]

--- a/test/integration/ferrum_pdf_integration_test.rb
+++ b/test/integration/ferrum_pdf_integration_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class FerrumPdfIntegrationTest < ActionDispatch::IntegrationTest
+  test "can generate a PDF" do
+    get "/pdfs/show.pdf"
+    assert_response :success
+    assert_equal "application/pdf", response.content_type
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Content-Disposition"], 'filename="example.pdf"'
+  end
+
+  test "can generate a PNG screenshot" do
+    get "/pdfs/show.png"
+    assert_response :success
+    assert_equal "image/png", response.content_type
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Content-Disposition"], 'filename="example.png"'
+  end
+
+  test "can generate a PDF from URL" do
+    get "/pdfs/url.pdf", params: { url: "http://example.com" }
+    assert_response :success
+    assert_equal "application/pdf", response.content_type
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Content-Disposition"], 'filename="example.pdf"'
+  end
+
+  test "can generate a PNG screenshot from URL" do
+    get "/pdfs/url.png", params: { url: "http://example.com" }
+    assert_response :success
+    assert_equal "image/png", response.content_type
+    assert_includes response.headers["Content-Disposition"], "inline"
+    assert_includes response.headers["Content-Disposition"], 'filename="example.png"'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,12 @@ end
 
 class ActiveSupport::TestCase
   setup do
-    FerrumPdf.reset_configuration!
+    # Store the original configuration
+    @original_config = FerrumPdf.configuration.dup
+  end
+
+  teardown do
+    # Restore the original configuration after each test
+    FerrumPdf.configuration.replace(@original_config)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,9 @@ if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
   ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
+
+class ActiveSupport::TestCase
+  setup do
+    FerrumPdf.reset_configuration!
+  end
+end


### PR DESCRIPTION
This PR introduces the ability to configure FerrumPdf globally using an initializer. The changes include:

1. Added a `configure` method to the FerrumPdf module to allow setting global options.
2. Updated the `browser` method to use the global configuration when creating a new Ferrum::Browser instance.
3. Added a `reset_configuration!` method for testing purposes.
4. Updated the README to explain how to use the new initializer.
5. Added tests to ensure the configuration works as expected.

These changes allow users to set default options for FerrumPdf in their Rails applications, improving flexibility and ease of use. Users can still override these global settings on a per-use basis when calling `render_pdf` or `render_screenshot`.

To use the new configuration, users can add an initializer file `config/initializers/ferrum_pdf.rb` in their Rails application:

```ruby
FerrumPdf.configure do |config|
  config.headless = true
  config.timeout = 20
  config.window_size = [1280, 800]
  # Add any other Ferrum options as needed
end
```

This PR aims to enhance the flexibility and customization options of FerrumPdf while maintaining backwards compatibility.