### PR TITLE
fix section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bundle add "ferrum_pdf"
 
 ## Usage
 
-You can use FerrumPdf to render [PDFs](#pdfs) and [Screenshots](#screenshots)
+You can use FerrumPdf to render [PDFs](#-pdfs) and [Screenshots](#-screenshots)
 
 ### 📄 PDFs
 
@@ -109,10 +109,10 @@ See [Chrome DevTools Protocol docs](https://chromedevtools.github.io/devtools-pr
 
 There are two ways to render Screenshots:
 
-* [FerrumPdf.render_screenshot](#render-screenshot)
+* [FerrumPdf.render_screenshot](#render-screenshots)
 * [render_screenshot in Rails](#render-screenshots-from-rails-controllers)
 
-#### Render Screenshot from Rails controller
+#### Render Screenshots from Rails controllers
 
 Use the `render_screenshot` helper in Rails controllers to render a PDF from the current action.
 


### PR DESCRIPTION
since the pdf and screenshot sections have emojis, the generated hrefs include a - in it.

![CleanShot 2024-10-09 at 23 09 19@2x](https://github.com/user-attachments/assets/78420b31-a16f-47ef-9c8e-1854222c9322)
