### PR TITLE
Adjust FLY_HOSTING_GUIDE to reflect changed FerrumPdf behavior

### DIFF
--- a/FLY_HOSTING_GUIDE.md
+++ b/FLY_HOSTING_GUIDE.md
@@ -8,38 +8,47 @@ to make sure Chrome is installed via Docker and running with the --no-sandbox fl
 First, add these dependencies to the Dockerfile used when deploying to Fly.io.
 
 ```
-ENV DOCKER_BUILD=1
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     chromium chromium-sandbox fonts-liberation libappindicator3-1 xdg-utils && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt
 ```
 
-I've also set `DOCKER_BUILD`, so the initializer is skipped when building the
-image (FerrumPdf will timeout since Chrome is not yet installed).
-
 ## Initialize with options
 
 Fly.io does not allow Chrome to run in sandbox mode, so we need to disable it.
 
+Additionally, in my testing, setting browser options via FerrumPdf did not work
+as expected once deployed. In production, we need to initialize Ferrum::Browser directly and
+set it directly in FerrumPdf.
+
 ```ruby
 # config/initializers/ferrum.rb
 
-return if ENV['DOCKER_BUILD']
+if Rails.env.production?
+  require 'ferrum'
 
-options = {
-  process_timeout: 30,
-  browser_options: {
-    'no-sandbox' => nil
-  }
-}
+  FERRUM_BROWSER = Ferrum::Browser.new(
+    browser_options: {
+      "no-sandbox" => true,
+      "headless" => "new"
+    },
+    process_timeout: 30,
+    browser_path: '/usr/bin/chromium'
+  )
 
-options = options.merge(browser_path: '/usr/bin/chromium') if Rails.env.production?
-
-FerrumPdf.browser(options)
+  # Configure FerrumPdf to use our browser instance
+  module FerrumPdf
+    class << self
+      def browser
+        FERRUM_BROWSER
+      end
+    end
+  end
+end
 ```
 
-Additionally, increasing the process timeout avoids code reloading issues in
+Increasing the process timeout avoids code reloading issues in
 development as detailed here: [Possibility to set Ferrum timeout to overcome code reloading issues in Development](https://github.com/excid3/ferrum_pdf/issues/5).
 
 `fly deploy` these changes, confirm the build step succeeds and FerrumPdf generates pdfs as expected.


### PR DESCRIPTION
Not sure what changed, but the FerrumPdf setup on Fly started failing as of late, took a different approach to get it working.