### PR TITLE
Add support for browser options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add support for `browser_options`
+
 ### 0.3.0
 
 * Add `FerrumPdf.include_controller_module = false` option to skip adding `render_pdf` Rails helper

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -20,20 +20,20 @@ module FerrumPdf
       @browser ||= Ferrum::Browser.new(options)
     end
 
-    def render_pdf(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, pdf_options: {})
-      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize) do |page|
+    def render_pdf(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, pdf_options: {}, browser_options: {})
+      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize, browser_options:) do |page|
         page.pdf(**pdf_options.with_defaults(encoding: :binary))
       end
     end
 
-    def render_screenshot(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, screenshot_options: {})
-      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize) do |page|
+    def render_screenshot(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, screenshot_options: {}, browser_options: {})
+      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize, browser_options:) do |page|
         page.screenshot(**screenshot_options.with_defaults(encoding: :binary, full: true))
       end
     end
 
-    def render(host:, protocol:, html: nil, url: nil, authorize: nil)
-      browser.create_page do |page|
+    def render(host:, protocol:, html: nil, url: nil, authorize: nil, browser_options: {})
+      browser(**browser_options).create_page do |page|
         page.network.authorize(user: authorize[:user], password: authorize[:password]) { |req| req.continue } if authorize
         if html
           page.content = FerrumPdf::HTMLPreprocessor.process(html, host, protocol)


### PR DESCRIPTION
This PR allows to configure the options that are passed when initializing [Ferrum::Browser](https://www.rubydoc.info/gems/ferrum/Ferrum%2FBrowser:initialize).

```ruby
FerrumPdf
  .render_pdf(
    html: render_content,
    pdf_options: { ... },
    browser_options: {
      headless: false,
      browser_options: {
        "no-sandbox" => true
      }
    }
  )
```