### PR TITLE
Adding network.wait_for_idle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ FerrumPdf.render_pdf(
   url: "https://example.com", # or provide a URL to the content
   host: request.base_url + "/", # Used for setting the host for relative paths
   protocol: request.protocol, # Used for handling relative protocol paths
-  authorize: {user: "username", password: "password"}, # Used for authenticating with basic auth
+  authorize: { user: "username", password: "password" }, # Used for authenticating with basic auth
+  wait_for_idle_options: { connections: 0, duration: 0.05, timeout: 5 }, # Used for setting network wait_for_idle options
 
   pdf_options: {
     landscape: false, # paper orientation

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -20,8 +20,8 @@ module FerrumPdf
       @browser ||= Ferrum::Browser.new(options)
     end
 
-    def render_pdf(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, pdf_options: {})
-      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize) do |page|
+    def render_pdf(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, wait_for_idle_options: nil, pdf_options: {})
+      render(host: host, protocol: protocol, html: html, url: url, authorize: authorize, wait_for_idle_options: wait_for_idle_options) do |page|
         page.pdf(**pdf_options.with_defaults(encoding: :binary))
       end
     end
@@ -32,15 +32,15 @@ module FerrumPdf
       end
     end
 
-    def render(host:, protocol:, html: nil, url: nil, authorize: nil)
+    def render(host:, protocol:, html: nil, url: nil, authorize: nil, wait_for_idle_options: nil)
       browser.create_page do |page|
         page.network.authorize(user: authorize[:user], password: authorize[:password]) { |req| req.continue } if authorize
         if html
           page.content = FerrumPdf::HTMLPreprocessor.process(html, host, protocol)
-          page.network.wait_for_idle
         else
           page.go_to(url)
         end
+        page.network.wait_for_idle(**wait_for_idle_options)
         yield page
       end
     rescue Ferrum::DeadBrowserError

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -42,6 +42,8 @@ module FerrumPdf
         end
         page.network.wait_for_idle(**wait_for_idle_options)
         yield page
+      ensure
+        page.close
       end
     rescue Ferrum::DeadBrowserError
       retry

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -34,7 +34,7 @@ module FerrumPdf
 
     def render(host:, protocol:, html: nil, url: nil, authorize: nil, wait_for_idle_options: nil)
       browser.create_page do |page|
-        page.network.authorize(user: authorize[:user], password: authorize[:password]) { |req| req.continue } if authorize
+        page.network.authorize(**authorize) { |req| req.continue } if authorize
         if html
           page.content = FerrumPdf::HTMLPreprocessor.process(html, host, protocol)
         else


### PR DESCRIPTION
@excid3 Thanks for this gem! I'm converting our application to use this, however, I ran into an issue that requires `page.go_to(url)` to call `page.network.wait_for_idle` to allow in-page JavaScript processing to finish. As such, I made a few changes and would appreciate your review, feedback, and consideration.

This PR:
- Moves `page.network.wait_for_idle` outside the `browser.create_page` `if...else` block so that both cases can make use of it
- Adds `wait_for_idle_options` named parameter to `render_pdf` to allow setting all of the available `network.wait_for_idle` [options](https://github.com/rubycdp/ferrum?tab=readme-ov-file#wait_for_idleoptions--boolean)
- Adds `ensure` with `page.close` to clean up network connections
- Updates the Readme
- And, since I was there, simplifies the `authorize` hash to `**authorize` in `browser.create_page`