### PR TITLE
Add browser quit method

### DIFF
--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -20,6 +20,11 @@ module FerrumPdf
       @browser ||= Ferrum::Browser.new(options)
     end
 
+    def quit
+      @browser&.quit
+      @browser = nil
+    end
+
     def render_pdf(html: nil, url: nil, host: nil, protocol: nil, authorize: nil, wait_for_idle_options: nil, pdf_options: {})
       render(host: host, protocol: protocol, html: html, url: url, authorize: authorize, wait_for_idle_options: wait_for_idle_options) do |page|
         page.pdf(**pdf_options.with_defaults(encoding: :binary))


### PR DESCRIPTION
This adds support to close the browser via the [`quit`](https://github.com/rubycdp/ferrum/blob/main/lib/ferrum/browser.rb#L212C1-L220C8) method available from [Ferrum](https://github.com/rubycdp/ferrum).

I found this useful in the situation where a long lasting process does the PDF rendering, and it's not desirable to have the chrome process floating around once rendering has finished.
