### PR TITLE
Minor correction to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ end
 You can also customize which template is rendered. This will render the template to string with `render_to_string` in Rails, then pass it along to Chrome. For example, you can add headers and footers using `pdf_options` and use a specific layout:
 
 ```ruby
-render(
-  ferrum_pdf: {
+# In your controller action
+render ferrum_pdf: {
     display_header_footer: true,
     header_template: FerrumPdf::DEFAULT_HEADER_TEMPLATE,
     footer_template: FerrumPdf::DEFAULT_FOOTER_TEMPLATE
@@ -49,7 +49,6 @@ render(
   template: "pdf",
   disposition: :inline,
   filename: "example.pdf"
-)
 ```
 
 #### Render PDFs
@@ -129,8 +128,8 @@ end
 You can also customize which template is rendered. This will render the template to string with `render_to_string` in Rails, then pass it along to Chrome.
 
 ```ruby
-render(
-  ferrum_screenshot: {
+# In your controller action
+render ferrum_screenshot: {
     format: "png" # or "jpeg"
     quality: nil # Integer 0-100 works for jpeg only
     full: true # Boolean whether you need full page screenshot or a viewport
@@ -143,7 +142,6 @@ render(
   template: "example",
   disposition: :inline,
   filename: "example.png"
-)
 ```
 
 See [Ferrum screenshot docs](https://github.com/rubycdp/ferrum?tab=readme-ov-file#screenshotoptions--string--integer) for the full set of options.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ end
 You can also customize which template is rendered. This will render the template to string with `render_to_string` in Rails, then pass it along to Chrome. For example, you can add headers and footers using `pdf_options` and use a specific layout:
 
 ```ruby
-render ferrum_pdf: {
+render(
+  ferrum_pdf: {
     display_header_footer: true,
     header_template: FerrumPdf::DEFAULT_HEADER_TEMPLATE,
     footer_template: FerrumPdf::DEFAULT_FOOTER_TEMPLATE
@@ -48,6 +49,7 @@ render ferrum_pdf: {
   template: "pdf",
   disposition: :inline,
   filename: "example.pdf"
+)
 ```
 
 #### Render PDFs
@@ -127,7 +129,8 @@ end
 You can also customize which template is rendered. This will render the template to string with `render_to_string` in Rails, then pass it along to Chrome.
 
 ```ruby
-render ferrum_screenshot: {
+render(
+  ferrum_screenshot: {
     format: "png" # or "jpeg"
     quality: nil # Integer 0-100 works for jpeg only
     full: true # Boolean whether you need full page screenshot or a viewport
@@ -137,9 +140,10 @@ render ferrum_screenshot: {
     background_color: nil # Ferrum::RGBA.new(0, 0, 0, 0.0)
   },
   layout: "example",
-  template: "example"
+  template: "example",
   disposition: :inline,
   filename: "example.png"
+)
 ```
 
 See [Ferrum screenshot docs](https://github.com/rubycdp/ferrum?tab=readme-ov-file#screenshotoptions--string--integer) for the full set of options.


### PR DESCRIPTION
After close: https://github.com/excid3/ferrum_pdf/pull/70

Parentheses and commas have been added. 

Also, don't forget to remove pdf_options and screenshot_options from render. ))))