### PR TITLE
Raise `Ferrum::TimeoutError` when network is not idle

### DIFF
--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -103,12 +103,12 @@ module FerrumPdf
           end
 
           # Wait for everything to load
-          page.network.wait_for_idle(**wait_for_idle_options)
+          page.network.wait_for_idle!(**wait_for_idle_options)
 
           yield browser, page
         end
       end
-    rescue Ferrum::DeadBrowserError
+    rescue Ferrum::DeadBrowserError, Ferrum::TimeoutError
       try += 1
       if try <= retries
         with_browser(&:restart)

--- a/lib/ferrum_pdf.rb
+++ b/lib/ferrum_pdf.rb
@@ -86,7 +86,7 @@ module FerrumPdf
     # This automatically applies HTML preprocessing if `html:` is present
     #
     def load_page(url: nil, html: nil, base_url: nil, authorize: nil, wait_for_idle_options: nil, browser: nil, retries: 1)
-      try = 0
+      try ||= 0
       wait_for_idle_options ||= {}
 
       with_browser(browser) do |browser|


### PR DESCRIPTION
I also fixed an infinite loop bug where the `try` count was being reset to 0 every retry.