### PR TITLE
HTMLPreProcessing Fix For Root Relative and Page Relative URLs

### DIFF
--- a/lib/ferrum_pdf/html_preprocessor.rb
+++ b/lib/ferrum_pdf/html_preprocessor.rb
@@ -4,7 +4,7 @@ module FerrumPdf
   # Sourced from the PDFKit project
   # @see https://github.com/pdfkit/pdfkit
   module HTMLPreprocessor
-    # Change relative paths to absolute, and relative protocols to absolute protocols
+    # Change root relative and page relative paths to absolute, and relative protocols to absolute protocols
     #
     #   process("Some HTML", "https://example.org")
     #
@@ -12,17 +12,28 @@ module FerrumPdf
       return html if base_url.blank?
 
       base_url += "/" unless base_url.end_with? "/"
-      protocol = base_url.split("://").first
-      html = translate_relative_paths(html, base_url) if base_url
+      uri = URI(base_url)
+      port_part = uri.port && ![80, 443].include?(uri.port) ? ":#{uri.port}" : ""
+      root_url  = "#{uri.scheme}://#{uri.host}#{port_part}/"
+      protocol = uri.scheme
+
+      html = translate_root_relative_paths(html, root_url) if root_url
+      html = translate_page_relative_paths(html, base_url) if base_url
       html = translate_relative_protocols(html, protocol) if protocol
       html
     end
 
-    def self.translate_relative_paths(html, base_url)
-      # Try out this regexp using rubular http://rubular.com/r/hiAxBNX7KE
-      html.gsub(%r{(href|src)=(['"])/([^/"']([^"']*|[^"']*))?['"]}, "\\1=\\2#{base_url}\\3\\2")
+    def self.translate_root_relative_paths(html, root_url)
+      # Try out this regexp using rubular https://rubular.com/r/3624VOEgG5atZn
+      html.gsub(%r{(href|src)=(['"])/(?!/)([^/"']([^"']*|[^"']*))?['"]}, "\\1=\\2#{root_url}\\3\\2")
     end
-    private_class_method :translate_relative_paths
+    private_class_method :translate_root_relative_paths
+
+    def self.translate_page_relative_paths(html, base_url)
+      # Try out this regexp using rubular https://rubular.com/r/axnIqShzHu6sLs
+      html.gsub(%r{(href|src)=(['"])(?!/|[a-zA-Z][a-zA-Z0-9+\-.]*:)([^/"']([^"']*|[^"']*))?['"]}, "\\1=\\2#{base_url}\\3\\2")
+    end
+    private_class_method :translate_page_relative_paths
 
     def self.translate_relative_protocols(body, protocol)
       # Try out this regexp using rubular http://rubular.com/r/0Ohk0wFYxV

--- a/test/html_preprocessing_test.rb
+++ b/test/html_preprocessing_test.rb
@@ -10,13 +10,36 @@ class HtmlPreProcessingTest< ActiveSupport::TestCase
     assert_equal "<a href=\"/example.pdf\">PDF</a>", FerrumPdf::HTMLPreprocessor.process("<a href=\"/example.pdf\">PDF</a>", "")
   end
 
-  test "replaces relative paths" do
-    assert_equal "<a href=\"http://example.org/example.pdf\">PDF</a>", FerrumPdf::HTMLPreprocessor.process("<a href=\"/example.pdf\">PDF</a>", "http://example.org")
-    assert_equal "<a href=\"https://example.com/example.pdf\">PDF</a>", FerrumPdf::HTMLPreprocessor.process("<a href=\"/example.pdf\">PDF</a>", "https://example.com")
+  test "replaces root-relative paths with root url" do
+    base_url = "https://example.com/some/deep/path"
+    input = "<a href=\"/example.pdf\">PDF</a><img src=\"/assets/app.png\">"
+    output = FerrumPdf::HTMLPreprocessor.process(input, base_url)
+
+    assert_includes output, "href=\"https://example.com/example.pdf\""
+    assert_includes output, "src=\"https://example.com/assets/app.png\""
+  end
+
+  test "replaces page-relative paths with base url" do
+    base_url = "https://example.com/some/deep/path/"
+    input = "<a href=\"docs/example.pdf\">PDF</a><script src=\"js/app.js\"></script>"
+    output = FerrumPdf::HTMLPreprocessor.process(input, base_url)
+
+    assert_includes output, "href=\"https://example.com/some/deep/path/docs/example.pdf\""
+    assert_includes output, "src=\"https://example.com/some/deep/path/js/app.js\""
   end
 
   test "replaces relative protocols" do
     assert_equal "<a href=\"http://domain.com/example.pdf\">PDF</a>", FerrumPdf::HTMLPreprocessor.process("<a href=\"//domain.com/example.pdf\">PDF</a>", "http://example.org")
     assert_equal "<a href=\"https://domain.com/example.pdf\">PDF</a>", FerrumPdf::HTMLPreprocessor.process("<a href=\"//domain.com/example.pdf\">PDF</a>", "https://example.com")
+  end
+
+  test "does not rewrite absolute, mailto, or data URLs" do
+    base_url = "https://example.com/base/"
+    input = "<a href=\"https://other.com/file.pdf\">abs</a><a href=\"mailto:test@example.com\">mail</a><img src=\"data:image/png;base64,AAA\">"
+    output = FerrumPdf::HTMLPreprocessor.process(input, base_url)
+
+    assert_includes output, "href=\"https://other.com/file.pdf\""
+    assert_includes output, "href=\"mailto:test@example.com\""
+    assert_includes output, "src=\"data:image/png;base64,AAA\""
   end
 end


### PR DESCRIPTION
When you generate a PDF and specify the `base_url` argument, it prepends that to the URLs defined in the source HTML. When doing so, page-relative URLs (i.e. "my/path") and root-relative URLs (i.e. "/my/path") have the `base_url` prepended, even though a browser would actually treat these URLs very differently.

This commit prepends the root URL (extracted from `base_url`) to root-relative URLs and continues to prepend the `base_url` to page-relative URLs.

---

For example, if I have a page that lives here:
- https://example.com/some/deep/path/

When I access that URL from a browser, if any asset on the page has a `/` prefix, the browser will request it off of the root URL, while if there is no leading slash, the browser will request it off of the current page URL path. So if I am on the page provided above and a couple `link` tags are present, it would function like the following in a real browser:
- `<link rel="stylesheet" href="/assets/root_stylesheet.css">`:
    - Requests `https://example.com/assets/root_stylesheet.css`
- `<link rel="stylesheet" href="my_page_stylesheet.css">`:
    - Requests `https://example.com/some/deep/path/my_page_stylesheet.css`

So if I were to generate a PDF from this page, I would want to set the `base_url` to `https://example.com/some/deep/path/`. However, doing so would result in the following assets being present in the HTML that `HTMLPreprocessor` generates:
- `https://example.com/some/deep/path/assets/root_stylesheet.css`
- `https://example.com/some/deep/path/my_page_stylesheet.css`

The first URL is incorrect while only the second one is fine.

This PR addresses this situation and treats relative paths the same as the browser does.