### PR TITLE
fix: updates the ferrum dependency to the compatible version

### DIFF
--- a/ferrum_pdf.gemspec
+++ b/ferrum_pdf.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "ferrum", "~> 0.15"
+  spec.add_dependency "ferrum", "~> 0.16"
 end


### PR DESCRIPTION
`ferrum_pdf` uses the bang version of `network.wait_for_idle!` from ferrum, which was only introduced in version 0.16, but currently it only requires version `0.15` Which can lead to `NoMethodError` if somehow you don't have the latest ferrum version and end up with version `0.15`. This dependency update will avoid such errors.

usage of the bang version: https://github.com/excid3/ferrum_pdf/blob/b243d944568d0b8bd9e0443239e126ba3af3a517/lib/ferrum_pdf.rb#L112 

changelog: https://github.com/rubycdp/ferrum/blob/main/CHANGELOG.md#016---dec-1-2024

commit that adds the bank version: https://github.com/rubycdp/ferrum/commit/40c34ab3417aade45db2d169fb93fc55ab9d42ae

